### PR TITLE
Function that binds to chokidar `on` event for debug view perspective.

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -43,6 +43,7 @@ let config;
 if (fs.existsSync(appDir + '/monitor-config.js')) {
   config = require(appDir + '/monitor-config.js');
   ignore = ignore.concat(config.addIgnore || []);
+  on = config.on;
 }
 
 ignore = ignore.map(rule => unixSlashes(rule));
@@ -107,6 +108,8 @@ function change(event, filename) {
     if (!timeout) {
       timeout = setTimeout(function() {
         timeout = null;
+        // bind it to monitor-config.js on chokidar event
+        on(event, filename, apos);
         return change(filename);
       }, 100);
     }

--- a/monitor.js
+++ b/monitor.js
@@ -109,7 +109,9 @@ function change(event, filename) {
       timeout = setTimeout(function() {
         timeout = null;
         // bind it to monitor-config.js on chokidar event
-        on(event, filename, apos);
+        if (on){
+          on(event, filename, apos);
+        }
         return change(filename);
       }, 100);
     }


### PR DESCRIPTION
I make an external function that extends from `monitor-config.js` for better log file changes using `apos.utils.log`. It is useful to debug or to watch which files are changes and also to make sure `addIgnore` works when restarting the site. This is extremely useful for me to see my site works perfectly and see the progress while restarting. I hope this would be beneficial too to other devs. For example :

```js
// in /monitor-config.js
module.exports = {
    on : function(event , filename , apos){
        apos.utils.log(event , filename)
    }
}
```

> If this PR agree to merge, could you publish to npm ? I would like to see an immediate effect and use it when update the package later 😄 . Also, if merged, I believe this should be documented in README too to let other devs know how to use it 😁 