### PR TITLE
Ignore modules' public files and views

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -1,6 +1,7 @@
 const chokidar = require('chokidar');
 const clear = require('clear-require');
 const fs = require('fs');
+const path = require('path');
 const anymatch = require('anymatch');
 const quote = require('regexp-quote');
 
@@ -12,7 +13,7 @@ try {
   appDir = process.cwd();
   entry = require(appDir + '/package.json').main;
   from = appDir + '/' + entry;
-  appDir = require('path').dirname(from);
+  appDir = path.dirname(from);
 } catch (e) {
   if (entry) {
     console.error(e);
@@ -32,6 +33,8 @@ appDir = unixSlashes(appDir);
 console.log('Watching ' + appDir);
 
 let ignore = [
+  appDir + '/lib/modules/*/public/**',
+  appDir + '/lib/modules/*/views/**',
   appDir + '/node_modules/**',
   appDir + '/public/modules/**',
   appDir + '/public/uploads/**',
@@ -78,6 +81,10 @@ function start() {
     console.error('You did not pass root to the apos object.');
     youNeed();
     process.exit(1);
+  }
+  var templateOptions = apos.options.modules ? apos.options.modules['apostrophe-templates'] : {};
+  if (templateOptions.viewsFolderFallback) {
+    ignore.push(path.join(templateOptions.viewsFolderFallback, '**'));
   }
   apos.options.afterListen = function(err) {
     if (err) {
@@ -133,7 +140,7 @@ function restart() {
 start();
 
 function unixSlashes(s) {
-  return s.replace(new RegExp(quote(require('path').sep), 'g'), '/');
+  return s.replace(new RegExp(quote(path.sep), 'g'), '/');
 }
 
 function youNeed() {

--- a/monitor.js
+++ b/monitor.js
@@ -34,7 +34,6 @@ console.log('Watching ' + appDir);
 
 let ignore = [
   appDir + '/lib/modules/*/public/**',
-  appDir + '/lib/modules/*/views/**',
   appDir + '/node_modules/**',
   appDir + '/public/modules/**',
   appDir + '/public/uploads/**',
@@ -81,10 +80,6 @@ function start() {
     console.error('You did not pass root to the apos object.');
     youNeed();
     process.exit(1);
-  }
-  var templateOptions = apos.options.modules ? apos.options.modules['apostrophe-templates'] : {};
-  if (templateOptions.viewsFolderFallback) {
-    ignore.push(path.join(templateOptions.viewsFolderFallback, '**'));
   }
   apos.options.afterListen = function(err) {
     if (err) {


### PR DESCRIPTION
Also ignore files in apostrophe-template's viewsFolderFallback.

Files in the `public` directories shouldn't have to trigger a restart of the entire apostrophe instance, since LESS/CSS files are recompiled as necessary on each request and front-end JS is simply downloaded again with every request. Something similar was already being done in the `nodemonConfig` for apostrophe-boilerplate: https://github.com/apostrophecms/apostrophe-boilerplate/pull/13

If I'm not mistaken, apostrophe also watches the views directory of each module and invalidates those files as needed (without the whole Apostrophe instance needing to restart).