### PR TITLE
Enable monitor to keep running in case Apostrophe can't start

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -67,7 +67,7 @@ chokidar.watch([appDir], {
 
 let apos = null;
 
-const errorHandingServer = http.createServer(function (req, res) {
+const errorHandlingServer = http.createServer(function (req, res) {
   res.writeHead(500, {'Content-Type': 'text/html'});
   res.write(`<body><h1>You have a code error</h1>
   <strong>${error.message}</strong><br />
@@ -96,7 +96,7 @@ function start() {
     }
 
     apos.options.afterInit = function (cb) {
-      errorHandingServer.close();
+      errorHandlingServer.close();
       cb();
     }
 
@@ -120,7 +120,7 @@ function start() {
     // If it's a new error, fire up our error handline server
     // and log the error details
     if (!error.warned) {
-      errorHandingServer.listen(3000)
+      errorHandlingServer.listen(3000 || process.env.PORT)
       console.error('An error occurred when restarting: ', e.message, e.stack);
       error = {
         message: e.message,

--- a/monitor.js
+++ b/monitor.js
@@ -69,9 +69,13 @@ let apos = null;
 
 const errorHandlingServer = http.createServer(function (req, res) {
   res.writeHead(500, {'Content-Type': 'text/html'});
-  res.write(`<body><h1>You have a code error</h1>
-  <strong>${error.message}</strong><br />
-  ${error.stack.split('<br />')}</body>`);
+  res.write(`<body>
+  <h1>You have a code error</h1>
+    <strong>${error.message}</strong><br />
+    <code>
+    ${escapeHtml(error.stack).replace('\n', '<br />')}
+    </code>
+  </body>`);
   res.end();
 });
 
@@ -120,7 +124,7 @@ function start() {
     // If it's a new error, fire up our error handline server
     // and log the error details
     if (!error.warned) {
-      errorHandlingServer.listen(3000 || process.env.PORT)
+      errorHandlingServer.listen(process.env.PORT || 3000)
       console.error('An error occurred when restarting: ', e.message, e.stack);
       error = {
         message: e.message,
@@ -187,4 +191,14 @@ function youNeed() {
   console.error('  root: module');
   console.error('  // the rest of your configuration follows as usual');
   console.error('};');
+}
+
+// https://stackoverflow.com/questions/1787322/htmlspecialchars-equivalent-in-javascript
+function escapeHtml(text) {
+  return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "clear-require": "^2.0.0",
     "intercept-require": "^1.1.0",
     "node-hook": "^1.0.0",
-    "regexp-quote": "0.0.0"
+    "regexp-quote": "0.0.0",
+    "stoppable": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
Current behaviour: if Apostrophe can't start (eg: syntax error in a module's index.js), monitor exits to the terminal.

This PR allows monitor to continue running in case Apostrophe doesn't start, and instead runs a basic HTTP server which will return the error message and stack dump, until the error is fixed and Apostrophe can run successfully again.